### PR TITLE
Add auto completion to alias

### DIFF
--- a/00 - Shortcuts.md
+++ b/00 - Shortcuts.md
@@ -31,7 +31,10 @@ Set up alias :
 Set up auto-completion : 
 
     echo "source <(kubectl completion bash)" >> ~/.bashrc
+    
+Set up auto-completion for alias : 
 
+    complete -F __start_kubectl k
 
 Display nodes:
 


### PR DESCRIPTION
You can also use auto completion for a shorthand alias
Ref: https://kubernetes.io/docs/reference/kubectl/cheatsheet/